### PR TITLE
Replace jsdom with happy-dom

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -1,0 +1,23 @@
+name: Tester
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tester:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+    - uses: actions/checkout@v7
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { NodePangu } = require('pangu');
 
 const pangu = new NodePangu();
 
-hexo.extend.filter.register('after_post_render', data => {
-  data.content = spacing(data.content);
+hexo.extend.filter.register('after_post_render', async data => {
+  data.content = await spacing(data.content);
   data.title = pangu.spacingText(data.title);
 }, 8);

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,17 +1,13 @@
 const path = require('path');
 const { readFileSync } = require('fs');
 const { runInNewContext } = require('vm');
-const { JSDOM } = require('jsdom');
-const dom = new JSDOM();
-const { window } = dom;
-const { document } = window;
 
-function loadPlugin(file) {
-  const path = require.resolve(file);
+function loadPlugin(file, window) {
+  const scriptPath = require.resolve(file);
 
   // Based on: https://github.com/joyent/node/blob/v0.10.33/src/node.js#L516
   const script = `(function(globalThis, { document, DocumentFragment, NodeFilter, Element, HTMLElement, Text, Node, getComputedStyle }, requestIdleCallback) {
-    ${readFileSync(path)}
+    ${readFileSync(scriptPath)}
   });`;
 
   const fn = runInNewContext(script);
@@ -25,9 +21,16 @@ function loadPlugin(file) {
 }
 
 const panguPackageDir = path.dirname(require.resolve('pangu/package.json'));
-const pangu = loadPlugin(path.join(panguPackageDir, 'dist/browser/pangu.umd.js'));
+const environment = import('happy-dom').then(({ Window }) => {
+  const window = new Window();
+  return {
+    document: window.document,
+    pangu: loadPlugin(path.join(panguPackageDir, 'dist/browser/pangu.umd.js'), window)
+  };
+});
 
-module.exports = function(content) {
+module.exports = async function(content) {
+  const { document, pangu } = await environment;
   document.body.innerHTML = content;
   pangu.spacingPage();
   return document.body.innerHTML;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Server side pangu.js filter for Hexo.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/next-theme/hexo-pangu#readme",
   "dependencies": {
-    "jsdom": "^29.0.0",
+    "happy-dom": "^20.11.1",
     "pangu": "9.0.0"
   }
 }

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const spacing = require('../lib/filter');
+
+test('spaces rendered HTML while preserving ignored content', async () => {
+  const cases = new Map([
+    [
+      '<p>中文<strong>English</strong>测试</p>',
+      '<p>中文<strong> English</strong> 测试</p>'
+    ],
+    [
+      '<p>中文<a href="#">English</a>测试</p>',
+      '<p>中文 <a href="#">English</a> 测试</p>'
+    ],
+    [
+      '<p>中文<code>English测试</code>English</p>',
+      '<p>中文<code>English测试</code> English</p>'
+    ],
+    [
+      '<pre>中文English</pre><p>中文English</p>',
+      '<pre>中文English</pre><p>中文 English</p>'
+    ],
+    [
+      '<p class="no-pangu-spacing">中文English</p>',
+      '<p class="no-pangu-spacing">中文English</p>'
+    ],
+    [
+      '<p>中文<!-- comment -->English</p>',
+      '<p>中文<!-- comment --> English</p>'
+    ]
+  ]);
+
+  for (const [input, expected] of cases) {
+    assert.equal(await spacing(input), expected);
+  }
+});
+
+test('keeps concurrent filter calls independent', async () => {
+  const [first, second] = await Promise.all([
+    spacing('<p>中文English</p>'),
+    spacing('<p>测试123</p>')
+  ]);
+
+  assert.equal(first, '<p>中文 English</p>');
+  assert.equal(second, '<p>测试 123</p>');
+});
+
+test('registers an asynchronous Hexo filter', async () => {
+  let filter;
+  global.hexo = {
+    extend: {
+      filter: {
+        register(type, callback, priority) {
+          assert.equal(type, 'after_post_render');
+          assert.equal(priority, 8);
+          filter = callback;
+        }
+      }
+    }
+  };
+
+  try {
+    require('../index');
+    const data = {
+      content: '<p>中文English</p>',
+      title: '中文Title123'
+    };
+
+    await filter(data);
+    assert.equal(data.content, '<p>中文 English</p>');
+    assert.equal(data.title, '中文 Title123');
+  } finally {
+    delete global.hexo;
+  }
+});


### PR DESCRIPTION
## Summary

- replace `jsdom` with `happy-dom` for server-side HTML processing
- initialize the ESM-only DOM implementation once and await it from the Hexo filter
- add regression coverage for cross-element spacing, ignored content, concurrent calls, and async Hexo registration
- run the tests on Node.js 20, 22, and 24 in GitHub Actions

## Why

The pangu browser build still needs a DOM to preserve spacing behavior across HTML element boundaries. `happy-dom` provides the DOM APIs used by pangu with lower processing overhead in this workload.

The previous local benchmark using the same parse, spacing, and serialization path measured:

| Input | jsdom | happy-dom |
| --- | ---: | ---: |
| ~10 KiB | 10.93 ms | 6.97 ms |
| ~100 KiB | 105.06 ms | 71.08 ms |

Because `happy-dom` is ESM-only, the filter now initializes it through a cached dynamic import and returns a Promise that Hexo waits for. Each DOM mutation and serialization pass remains synchronous, so concurrent render promises cannot interleave on the shared document.

## User Impact

No configuration changes are required. Existing pangu spacing rules, including ignored `code`, `pre`, and `no-pangu-spacing` content, are preserved.

## Validation

- `npm test`
- `npm pack --dry-run`
- `npx hexo cl && npx hexo g` in the local blog, generating 685 files successfully
